### PR TITLE
Improve mobile viewport handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#0f172a" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -128,7 +128,7 @@ function App() {
         display: 'flex', 
         justifyContent: 'center', 
         alignItems: 'center', 
-        height: '100vh',
+        height: '100dvh',
         fontSize: '1.1em',
         color: '#6b7280'
       }}>

--- a/src/components/SourceSelector.css
+++ b/src/components/SourceSelector.css
@@ -7,6 +7,8 @@
   top: 0;
   right: 0;
   height: 100vh;
+  height: 100dvh;
+  -webkit-overflow-scrolling: touch;
   width: 360px;
   overflow-y: auto;
   transform: translateX(100%);
@@ -344,6 +346,7 @@
   .source-selector-container {
     width: 100%;
     height: 60vh;
+    height: 60dvh;
     bottom: 0;
     top: auto;
     left: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -46,6 +46,7 @@ body {
     color: #e2e8f0;
     line-height: 1.6;
     min-height: 100vh;
+    min-height: 100dvh;
     position: relative;
     overflow-x: hidden;
 }
@@ -88,6 +89,7 @@ h1, h2, h3, h4, h5, h6 {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    min-height: 100dvh;
 }
 
 .app {
@@ -140,6 +142,7 @@ a:hover {
 
 .App {
     min-height: 100vh;
+    min-height: 100dvh;
     display: flex;
     flex-direction: column;
     position: relative;
@@ -150,6 +153,7 @@ a:hover {
   position: relative;
   z-index: 1;
   min-height: 100vh;
+  min-height: 100dvh;
   padding-top: 6rem;
 }
 


### PR DESCRIPTION
## Summary
- add viewport-fit and theme-color meta
- switch various layout heights to use dynamic vh units
- smooth mobile scroll for source selector

## Testing
- `npm install`
- `npm run lint` *(fails: Do not access Object.prototype method 'hasOwnProperty', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6864a180c89c83278f546b61af827852